### PR TITLE
Add Installation Guide on xtb-Python Package

### DIFF
--- a/source/setup.rst
+++ b/source/setup.rst
@@ -165,6 +165,11 @@ of shipped tarball, then it will append the directories ``bin/`` and ``python/``
 to your ``PATH`` variable, ``man/`` to your ``MANPATH``,
 ``lib/`` to your ``LD_LIBRARY_PATH`` and ``python/`` to your ``PYTHONPATH``.
 
+Installing Python Package
+=========================
+
+.. note:: the xtb-python package will be added in version 6.3
+
 Getting Help from ``xtb``
 =========================
 


### PR DESCRIPTION
This is work in progress for version 6.3

 - [ ] split user and developer documentation on Python-API
 - [ ] add instructions to install distributed python package
 - [ ] add details on functions included in xtb-module
