### PR TITLE
Allow toggling of admonition blocks

### DIFF
--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -13,10 +13,12 @@
 
 .rst-content .toggle .admonition-title:after {
   content: ' (show)';
+  font-style: italic;
 }
 
 .rst-content .toggle .admonition-title.open:after {
   content: ' (hide)';
+  font-style: italic;
 }
 
 .rst-content .toggle p:last-child {

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -12,11 +12,11 @@
 }
 
 .rst-content .toggle .admonition-title:after {
-  content: ' ▶';
+  content: ' (show)';
 }
 
 .rst-content .toggle .admonition-title.open:after {
-  content: ' ▼';
+  content: ' (hide)';
 }
 
 .rst-content .toggle p:last-child {

--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,0 +1,24 @@
+.rst-content .toggle {
+  background: none repeat scroll 0 0 #e7f2fa;
+  padding: 12px;
+  line-height: 24px;
+  margin-bottom: 24px;
+}
+
+.rst-content .toggle .admonition-title {
+  display: block;
+  clear: both;
+  cursor: pointer;
+}
+
+.rst-content .toggle .admonition-title:after {
+  content: ' ▶';
+}
+
+.rst-content .toggle .admonition-title.open:after {
+  content: ' ▼';
+}
+
+.rst-content .toggle p:last-child {
+  margin-bottom: 0;
+}

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -1,0 +1,14 @@
+{% extends "!page.html" %}
+
+{% block footer %}
+ <script type="text/javascript">
+    $(document).ready(function() {
+        $(".toggle > *").hide();
+        $(".toggle .admonition-title").show();
+        $(".toggle .admonition-title").click(function() {
+            $(this).parent().children().not(".admonition-title").toggle(400);
+            $(this).parent().children(".admonition-title").toggleClass("open");
+        })
+    });
+</script>
+{% endblock %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,6 +14,9 @@
 #import sys
 #sys.path.insert(0, os.path.abspath('.'))
 
+def setup(app):
+    app.add_css_file('custom.css')
+
 
 # -- Project information -----------------------------------------------------
 
@@ -59,7 +62,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
 
 # other default
 master_doc = 'contents'


### PR DESCRIPTION
Allows to toggle admonition blocks by adding the toggle class, the toggle mechanism is implemented as javascript in the footer and applied with custom CSS to the rst-content block.

Use in the documentation by:

```rst
.. admonition:: Input
    :class: toggle

    ...

.. note::
    :class: toggle

    ...
```