### PR TITLE
wide tables

### DIFF
--- a/source/_static/custom.css
+++ b/source/_static/custom.css
@@ -1,0 +1,9 @@
+.wy-table-responsive table td, .wy-table-responsive table th {
+    /* !important prevents the common CSS stylesheets from
+       overriding this as on RTD they are loaded after this stylesheet */
+    white-space: normal !important;
+}
+
+.wy-table-responsive {
+    overflow: visible !important;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,8 +14,7 @@
 #import sys
 #sys.path.insert(0, os.path.abspath('.'))
 
-def setup(app):
-    app.add_css_file('custom.css')
+
 # -- Project information -----------------------------------------------------
 
 project = 'xtb doc'
@@ -63,6 +62,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+html_css_files = [ "custom.css", ]
 html_static_path = ['_static']
 
 # other default

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,8 @@
 #import sys
 #sys.path.insert(0, os.path.abspath('.'))
 
-
+def setup(app):
+    app.add_css_file('custom.css')
 # -- Project information -----------------------------------------------------
 
 project = 'xtb doc'
@@ -62,7 +63,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ['_static']
 
 # other default
 master_doc = 'contents'


### PR DESCRIPTION
Make text in tables break and continue in new line, rather than continue and force the reader to scroll down to the end of the table and move the horizontal handle. 

