### PR TITLE
Addressed compilation error: double energy was not defined.

### DIFF
--- a/source/capi.rst
+++ b/source/capi.rst
@@ -74,6 +74,8 @@ GFN2-xTB calculation is given here.
 
 .. code-block:: c
 
+   #include <stddef.h>
+
    #include "xtb.h"
 
    int main (int argc, char** argv)

--- a/source/capi.rst
+++ b/source/capi.rst
@@ -76,9 +76,9 @@ GFN2-xTB calculation is given here.
 
    #include "xtb.h"
 
-   int
-   main (int argc, char** argv)
+   int main (int argc, char** argv)
    {
+     double energy = 0.0;
      int    const natoms = 7;
      int    const attyp[7] = {6,6,6,1,1,1,1};
      double const charge = 0.0;


### PR DESCRIPTION
The minimal example from the C API does not compile because the variable `double energy` has never been defined. 

Signed-off-by: Felix Pultar <felix.pultar@phys.chem.ethz.ch>