### PR TITLE
Fix Sphinx warnings during building the HTML docs

### DIFF
--- a/source/community/scine.rst
+++ b/source/community/scine.rst
@@ -16,14 +16,14 @@ into the SCINE tool chain.
 Each method is represented by its own ``Calculator`` and the entire wrapper
 constitutes a SCINE module that can be loaded dynamically at runtime.
 For more information on these concepts see the ``Scine::Core``
-`repository <https://github.com/qcscine/core>`_.
+`SCINE Core repository <https://github.com/qcscine/core>`_.
 
 License and Copyright Information
 ---------------------------------
 
 The SCINE XTB wrapper is distributed under the BSD 3-clause "New" or "Revised"
 License. For more license and copyright information, see the file ``LICENSE.txt``
-in the `repository <https://github.com/qcscine/xtb_wrapper>`_.
+in the `XTB Wrapper repository <https://github.com/qcscine/xtb_wrapper>`_.
 
 Note: this license does not cover the original `xtb` source code.
 

--- a/source/dipro.rst
+++ b/source/dipro.rst
@@ -1,5 +1,8 @@
 .. _dipro:
 
+.. |J(AB)| replace:: :math:`J_{AB}`
+.. |J(AB,eff)| replace:: :math:`J_{AB,eff}`
+
 -------
  DIPRO
 -------
@@ -226,10 +229,14 @@ This is a very simple example of a cofacial NCI complex of benzene and nitrobenz
             * wall-time:     0 d,  0 h,  0 min,  0.084 sec
             *  cpu-time:     0 d,  0 h,  0 min,  0.337 sec
             * ratio c/w:     3.996 speedup
-   
-DIPRO first performs a singlepoint calculation on the complex and yields the fragmentation of your input coordinates. Then, two singlepoint calculations on the fragments structures are performed. The DIPRO output lists which orbitals from the couplings fragments were considered for the coupling calculations, e.g. the HOMO from fragment 1 (here nitrobenzene) and the HOMO-1 from fragment 2 (here benzene), and their corresponding energies. The most important parts are the results for the coupling integrals |J(AB)| and |J(AB,eff)|. Furthermore, a total coupling averaged over the square sum of all individual couplings is printed. 
+
+DIPRO first performs a singlepoint calculation on the complex and yields the fragmentation of your input coordinates.
+Then, two singlepoint calculations on the fragments structures are performed.
+The DIPRO output lists which orbitals from the couplings fragments were considered for the coupling calculations, e.g. the HOMO from fragment 1 (here nitrobenzene) and the HOMO-1 from fragment 2 (here benzene), and their corresponding energies. 
+The most important parts are the results for the coupling integrals |J(AB)| and |J(AB,eff)|.
+Furthermore, a total coupling averaged over the square sum of all individual couplings is printed. 
 
 .. math:: 
-   total |J(AB,eff)| = \sqrt{\sum J(AB,eff)_i^2}
+   total |J(AB,eff)| = \sqrt{\sum |J(AB,eff)_i^2|}
 
 Please find more information on the theory and our implementation of DIPRO in our publication (J.Kohn, N.Gildemeister, D.Fazzi, S.Grimme, A.Hansen, `Efficient Calculation of Electronic Coupling Integrals with the Dimer Projection Method via a Density Matrix Tight-Binding Potential`, JCP **2023**, submitted).

--- a/source/enso_doc/enso_usage.rst
+++ b/source/enso_doc/enso_usage.rst
@@ -847,12 +847,12 @@ Handling of missing conformers:
   you are not missing a conformer which is high lying in energy at GFNn-xTB level. (See :ref:`backup <flags_settings>`)
 * The conformer might be wrongly sorted into a different conformer group by CREST and counted as a rotamer.
   To check this you can resort the complete CRE (including all rotamers and conformers) and check if the 
-  thresholds employed in the CREGEN sorting routine changes the CRE (See :ref:`crestxmpl` )
+  thresholds employed in the CREGEN sorting routine changes the CRE.
 
   .. code-block:: bash
-      
+
       crest coord -cregen crest_rotamers_6.xyz -bthr 12 -nmr > cregen.out
-   
+
   Here you have to inspect the printout and check if grouping/sorting of conformers is correct.
   If you find that there were conformers wrongly grouped because of sorting-thresholds not 
   suitable for the investigated system. You have to rerun the ENSO calculation on the new ensemble file.

--- a/source/gfnff.rst
+++ b/source/gfnff.rst
@@ -16,7 +16,7 @@ The main publication for ``GFN-FF`` can be found at: `Angewandte Chemie <https:/
 .. figure:: ../figures/gfnff.jpg
    :scale: 25 %
    :alt: gfnff
-   
+
 
 Theoretical background
 =================================

--- a/source/gsm.rst
+++ b/source/gsm.rst
@@ -7,14 +7,16 @@ Growing String Method
 .. contents::
 
 .. note::
-   
+
    ``gsm`` is not developed in our group but in the *ZimmermanGroup*, therefore this tutorial and the useage of GSM is without warranty of completness or correctness.
    ``gsm`` is not able to communicate with ``xtb``, therefore a fake ``orca`` output is created using the ``xtb`` values.
    To run a ``gsm`` calculation, the following programs / files are needed.
+
      1) gsm.orca          *in any valid path, e.g. your bin*
      2) inpfileq          *in the directory, where you want to execute your calculation*
      3) modified ograd    *in the directory, where you want to execute your calculation*
      4) tm2orca.py        *in any valid path, e.g. your bin*
+
    Those are distributed from our fork of ``gsm`` `here <https://github.com/grimme-lab/molecularGSM/releases/tag/rev1>`_ for your convenience.
    For further information and a detailed description on ``gsm``, see `ZimmermanGroup`_ and their `orca`_ interface.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,86 +6,57 @@ This user guide focuses on the semiempirical quantum mechanical methods GFNn-xTB
 their descendants, and corresponding composite schemes as implemented in the
 `xtb <https://github.com/grimme-lab/xtb>`_ (extended tight binding) program package.
 
-We provide a number of detailed guides dealing with common task that can
+We provide a number of detailed guides dealing with common tasks that can
 be performed easily with the ``xtb`` program.
 All guides are usually structured the same way, starting with some simple
-examples using only the commandline and the default settings followed
-by a trouble shooting section.
-Detailed inputs are provided in a ready to use fashion to solve some
+examples using only the command line and the default settings, followed
+by a troubleshooting section.
+Detailed inputs are provided in a ready-to-use fashion to solve some
 more special but still common tasks with ``xtb`` together with some
-insights into the theory used behind the scences.
+insights into the theory used behind the scenes.
 
 
 -------------
  Quick Links
 -------------
 
-.. panels::
-   :column: + text-center
+.. figure:: https://github.com/awvwgk/xtb-logo/raw/master/xtb.svg
+   :width: 25%
+   :alt: xtb
+   :align: center
 
-   .. image:: https://github.com/awvwgk/xtb-logo/raw/master/xtb.svg
-      :width: 75%
-      :alt: xtb
+   `Documentation for xtb <setup.html>`_
 
-   +++
+.. figure:: https://github.com/grimme-lab/crest/raw/master/assets/crest.png
+   :width: 25%
+   :alt: CREST
+   :align: center
 
-   .. link-button:: setup
-      :type: ref
-      :text: Documentation for xtb
-      :classes: btn-block stretched-link
+   `Documentation for CREST <https://crest-lab.github.io/crest-docs/>`_
 
-   ---
+.. figure:: ../figures/CENSO/censo_logo_300dpi.png
+   :width: 25%
+   :alt: CENSO
+   :align: center
 
-   .. image:: https://github.com/grimme-lab/crest/raw/master/assets/crest.png
-      :width: 50%
-      :alt: CREST
+   `Documentation for CENSO <CENSO_docs/censo.html>`_
 
-   +++
+.. figure:: ../figures/qcxms/qcxms_logo.svg
+   :width: 25%
+   :alt: QCxMS
+   :align: center
 
-   .. link-button:: https://crest-lab.github.io/crest-docs/
-      :type: ref
-      :text: Documentation for CREST
-      :classes: btn-block stretched-link
+   `Documentation for QCxMS <qcxms_doc/qcxms.html>`_
 
-   ---
+.. figure:: ../logo/logo_abtgrimme_desktop.png
+   :width: 25%
+   :alt: Grimme-lab
+   :align: center
 
-   .. image:: ../figures/CENSO/censo_logo_300dpi.png
-      :alt: CENSO
-
-   +++
-
-   .. link-button:: censo
-      :type: ref
-      :text: Documentation for CENSO
-      :classes: btn-block stretched-link
-
-   ---
-
-   .. image:: ../figures/qcxms/qcxms_logo.svg
-      :alt: QCxMS
-
-   +++
-
-   .. link-button:: qcxms
-      :type: ref
-      :text: Documentation for QCxMS
-      :classes: btn-block stretched-link
-
-   ---
-   :column: + col-lg-12 p-2
-
-   .. image:: ../logo/logo_abtgrimme_desktop.png
-      :width: 75%
-      :alt: Grimme-lab
-
-   +++
-
-   .. link-button:: https://github.com/grimme-lab
-      :text: Explore on GitHub
-      :classes: btn-block stretched-link
+   `Explore on GitHub <https://github.com/grimme-lab>`_
 
 --------------------------------------------
- Recent developments, news and publications
+ Recent developments, news, and publications
 --------------------------------------------
 
 .. postlist:: 5
@@ -103,14 +74,13 @@ The xTB-methods are now officially available in other quantum chemistry programs
 
  - in `Orca`_ 4.2 an IO-based interface to the ``xtb`` binary is available
  - `AMS`_ 2019 implements GFN1-xTB in their DFTB module
- - the `entos`_ program implements GFN1-xTB (also available in the webinterface)
+ - the `entos`_ program implements GFN1-xTB (also available in the web interface)
  - the computational chemistry framework `cuby4`_ supports ``xtb``
  - `Turbomole`_ does support GFN1-xTB and GFN2-xTB since version 7.4
  - `QCEngine`_ supports calculations with the ``xtb`` API
- - the `GMIN`_, `OPTIM`_, and `PATHSAMPLE`_ global optimization tools provide a ``xtb`` interface
- - `CP2K`_ has an GFN1-xTB implementation since version 7.1
+ - the `GMIN`_, `OPTIM`_, and `PATHSAMPLE`_ global optimization tools provide an ``xtb`` interface
+ - `CP2K`_ has a GFN1-xTB implementation since version 7.1
  - `DFTB+`_ support GFN1-xTB and GFN2-xTB since version 21.2
-
 
 .. _Orca: https://orcaforum.kofo.mpg.de
 .. _AMS: https://www.scm.com/product/dftb/
@@ -125,9 +95,9 @@ The xTB-methods are now officially available in other quantum chemistry programs
 .. _DFTB+: https://www.dftbplus.org/
 
 We missed your project here?
-No problem, just give us hint at the mailing list or open an issue at `github`_.
+No problem, just give us a hint at the mailing list or open an issue at `GitHub`_.
 
-.. _github: https://github.com/grimme-lab/xtb_docs/issues/new
+.. _GitHub: https://github.com/grimme-lab/xtb_docs/issues/new
 
 
 .. toctree::

--- a/source/oniom.rst
+++ b/source/oniom.rst
@@ -111,7 +111,8 @@ where :math:`[xyz]_{con}` and :math:`[xyz]_{host}` are coordinates of connector 
 .. figure:: ../figures/docs.png
    :align: center
 
-| 
+|
+
 To distinguish between different bonds the topology information from the ``low`` level method is used. 
 
 .. warning:: 

--- a/source/qcxms_doc/qcxms_plot.rst
+++ b/source/qcxms_doc/qcxms_plot.rst
@@ -25,9 +25,10 @@ The program is designed to run on Linux operating systems.
 
 Move the ``.mass_raw.agr`` file into the ``$HOME`` folder. Change into your working directory, in which you created the 
 *qcxms.res* or *qcxms_cid.res* file and run ``plotms``. This generates three files:
-   - `mass.agr` -> *XMGRACE* file using the `~/.mass_raw.agr` template file
-   - `results.jdx` -> *JCAMP-DX* ( *Joint Committee on Atomic and Molecular Physical* data) file 
-   - `results.csv` -> *CSV* (*comma seperated values*) file for spreadsheet programs (e.g. Excel)
+
+- `mass.agr` -> *XMGRACE* file using the `~/.mass_raw.agr` template file
+- `results.jdx` -> *JCAMP-DX* ( *Joint Committee on Atomic and Molecular Physical* data) file 
+- `results.csv` -> *CSV* (*comma seperated values*) file for spreadsheet programs (e.g. Excel)
 
 The spectra can be plotted as soon as the production run has started by using the `getres` script, which creates an 
 *tmpqcxms.res* file. The file has to be deleted before ``getres`` is used a second time.
@@ -61,23 +62,30 @@ There are some useful command-line options to manipulate your results.
 
 -v, --verbose
     print verbose options
+
 -f, --file <file>
     provide `.res` file for plotting the spectrum
+
 -t <x> <y>
     couting ions with charge *x* to *y* (give the value, e.g. "-t 1 2" for charge 1 to 2)
+
 -w, --width <real>
     broadening the charges by an standard distribution (given in decimal numbers between 0 and 1)
+
 -s, --cascades <integer>
     account only for only secondary and tertiary fragmentations (give the value, e.g. "-s 2" for secondary)
+
 -m, --min <integer>
     set minimum value for m/z, so rel. 100% value will be calculated for higher masses (x-axis)
+
 -i, --mzmin <real>
     set the minimum rel. intensity from which the signals are counted (y-axis)
+
 -p, --noisotope
     do not calculate the isotope pattern 
+
 -e, --exp <file>
     use the following file as input for comparison to the calculated spectrum
-
 
 
 Visualization of Trajectories

--- a/source/qcxms_doc/qcxms_run.rst
+++ b/source/qcxms_doc/qcxms_run.rst
@@ -18,8 +18,7 @@ Workflow of QCxMS
 --------
 
 1. Prepare a file with the equilibrium structure of your desired molecule M. For the CID mode,
-   the molecule has to be protonated. This can be done with the protonation tool of **CREST**
-   (see: :ref:`crestcmd`). 
+   the molecule has to be protonated. This can be done with the protonation tool of **CREST**.
 
 .. Attention:: 
   The structure files can have all formats supported by the `MCTC library <https://github.com/grimme-lab/mctc-lib>`_ ,
@@ -83,7 +82,7 @@ Workflow of QCxMS
    into the *.agr* file and a matching score is provided. Run: `plotms -i file.csv`.
 
 In each *TMPQCXMS/TMP.* file, a production run can be conducted by `qcxms -p` to test settings or take a look into the fragmentation
-processes in detail. Other `commandline`_ options are provided below.
+processes in detail. Other `qcxms_commandline`_ options are provided below.
 
 
 
@@ -400,7 +399,7 @@ Available Basissets in ORCA/TURBOMOLE:
 
 Command line Options
 ====================
-.. _commandline:
+.. _qcxms_commandline:
 
 -**c** / --**check**
     check IEE but do nothing (requires ground state trajectory). Writes IEE distribution in file *eimp.dat*.

--- a/source/xtb_ir.rst
+++ b/source/xtb_ir.rst
@@ -29,10 +29,11 @@ Mandatory keywords are:
 
 Please find additional keywords in the documentation for the ``thermo`` submodule.
 IR intensities, sometimes also called *Born charges*, can equivalently be obtained from 
-   1. mixed 2nd derivatives of the energy with respect to atomic positions and external
-      electric field
-   2. 1st derivative of dipole moment with respect to atomic positions
-   3. 1st derivative of forces with respect to external electric field
+
+1. mixed 2nd derivatives of the energy with respect to atomic positions and external
+   electric field
+2. 1st derivative of dipole moment with respect to atomic positions
+3. 1st derivative of forces with respect to external electric field
 
 In DFTB+, the second pathway is employed.
 This module aims to easen the calculation of SQM solid state IR spectra for large molecular


### PR DESCRIPTION
- using `sphinx==8.1.3` and `python==3.13.0`
- errors were similar / equivalent throughout different versions of `python` and `sphinx`

With these updates, a clean build process can be ensured.