### PR TITLE
Adds ethanol for ALPB

### DIFF
--- a/source/gbsa.rst
+++ b/source/gbsa.rst
@@ -89,6 +89,7 @@ Here is a list of the available solvents.
  Dioxane         x                         x                         x
  DMF             x                         x            x            x
  DMSO            x            x            x            x            x
+ Ethanol         x                         x                         x
  Ether           x            x            x            x            x
  Ethylacetate    x                         x                         x
  Furane          x                         x                         x


### PR DESCRIPTION
First of all, thank you so much for xTB developers for developing and maintaining the xTB code!

This PR is a follow-up of #127. I found that ALPB `ethanol` is actually available in xTB with e.g. `xtb benzene.xyz --alpb ethanol`. I confirmed this with actual calculations ([ALPB.zip](https://github.com/user-attachments/files/20890171/ALPB.zip)) as well as with the following source codes:
 
https://github.com/grimme-lab/xtb/blob/d3f212ba83287290efafee6580670d02d7b2f49d/src/solv/model.f90#L147
https://github.com/grimme-lab/xtb/blob/d3f212ba83287290efafee6580670d02d7b2f49d/src/solv/model.f90#L351
https://github.com/grimme-lab/xtb/blob/d3f212ba83287290efafee6580670d02d7b2f49d/src/solv/model.f90#L378
https://github.com/grimme-lab/xtb/blob/d3f212ba83287290efafee6580670d02d7b2f49d/src/solv/model.f90#L408

The `ethanol` is however not documented [on the website](https://xtb-docs.readthedocs.io/en/latest/gbsa.html), which will hopefully be fixed with the present PR.